### PR TITLE
Updates: Sharding Support, Logging, vendor URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,18 @@ This is a plugin to allow `magellan` test runs to report to the Admiral2 dashboa
 
 **PLEASE NOTE: v3.0.0 would only be compatible with [Magellan](https://github.com/TestArmada/magellan) v10.0.0 and higher**
 
+## Configuration
+
+|Environment Variable|Required?|Description|Example|
+|---|---|---|---|
+|ADMIRAL_URL|required|The URL of the Admiral2 server|i.e `http://host-where-admiral-lives:3000/`|
+|ADMIRAL_PROJECT|required|An identifier for a project|i.e. `main-app`, `blog`, `product-page`, etc|
+|ADMIRAL_PHASE|required|A lifecycle phase descriptor like `pr-verify`, `master-verify`, etc|``|
+|ADMIRAL_CI_BUILD_URL|optional|An URL to a CI report for this run|`http://travis-ci.org/SomeOrg/someproject/builds/189605665`|
+|ADMIRAL_RUN_DISPLAY_NAME|optional|A description of the build that a given run represents|i.e `PR #26 - add unit tests`|
+|ADMIRAL_RUN_ID|optional|A unique identifier to tie together multiple parallel instances of the reporter into a single report|a uuid string, i.e. `462E43EA-002B-4F4B-A711-261B9894E4AA`|
+|ADMIRAL_REPORTER_DEBUG|optional|enable detailed logging for debugging|leave undefined or set to `1`|
+
 ## Licenses
 
 All code not otherwise specified is Copyright Wal-Mart Stores, Inc.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This is a plugin to allow `magellan` test runs to report to the Admiral2 dashboa
 |---|---|---|---|
 |ADMIRAL_URL|required|The URL of the Admiral2 server|i.e `http://host-where-admiral-lives:3000/`|
 |ADMIRAL_PROJECT|required|An identifier for a project|i.e. `main-app`, `blog`, `product-page`, etc|
-|ADMIRAL_PHASE|required|A lifecycle phase descriptor like `pr-verify`, `master-verify`, etc|``|
+|ADMIRAL_PHASE|required|A lifecycle phase or build type descriptor|i.e. `pr-verify`, `master-verify`, etc|
 |ADMIRAL_CI_BUILD_URL|optional|An URL to a CI report for this run|`http://travis-ci.org/SomeOrg/someproject/builds/189605665`|
 |ADMIRAL_RUN_DISPLAY_NAME|optional|A description of the build that a given run represents|i.e `PR #26 - add unit tests`|
 |ADMIRAL_RUN_ID|optional|A unique identifier to tie together multiple parallel instances of the reporter into a single report|a uuid string, i.e. `462E43EA-002B-4F4B-A711-261B9894E4AA`|

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "testarmada-magellan-admiral2-plugin",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "description": "Magellan reporter plugin that provides Admiral2 dashboard support",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "homepage": "https://github.com/TestArmada/magellan-admiral2-plugin#readme",
   "dependencies": {
+    "cli-color": "^1.2.0",
     "mocha": "^3.2.0",
     "node-fetch": "^1.5.3",
     "q": "^1.4.1"

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,0 +1,34 @@
+"use strict";
+
+const util = require("util");
+const clc = require("cli-color");
+const debug = process.env.ADMIRAL_REPORTER_DEBUG ? true : false;
+
+const PREFIX = "Magellan Admiral2 Plugin";
+
+module.exports = {
+  output: console,
+
+  debug(msg) {
+    /* istanbul ignore if */
+    if (debug) {
+      const deb = clc.blueBright("[DEBUG]");
+      this.output.log(util.format("%s [%s] %s", deb, PREFIX, msg));
+    }
+  },
+  log(msg) {
+    const info = clc.greenBright("[INFO]");
+    this.output.log(util.format("%s [%s] %s", info, PREFIX, msg));
+  },
+  warn(msg) {
+    const warn = clc.yellowBright("[WARN]");
+    this.output.warn(util.format("%s [%s] %s", warn, PREFIX, msg));
+  },
+  err(msg) {
+    const err = clc.redBright("[ERROR]");
+    this.output.error(util.format("%s [%s] %s", err, PREFIX, msg));
+  },
+  loghelp(msg) {
+    this.output.log(msg);
+  }
+};

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -9,50 +9,85 @@ var ADMIRAL_PROJECT = process.env.ADMIRAL_PROJECT;
 var ADMIRAL_PHASE = process.env.ADMIRAL_PHASE;
 var ADMIRAL_RUN = process.env.ADMIRAL_RUN_ID;
 
+var ADMIRAL_CI_BUILD_URL = process.env.ADMIRAL_SHARD_BUILD_URL
+var ADMIRAL_RUN_DISPLAY_NAME = process.env.ADMIRAL_RUN_DISPLAY_NAME;
+
+var debugMode = process.env.ADMIRAL_REPORTER_DEBUG ? true : false;
+
+var isSharded = ADMIRAL_RUN ? true : false;
+
 Reporter.prototype = {
 
   initialize: function () {
     var deferred = Q.defer();
 
-    console.log("Magellan Admiral2 reporter initializing with settings:");
-    console.log("      URL: " + ADMIRAL_URL);
-    console.log("  project: " + ADMIRAL_PROJECT);
-    console.log("    phase: " + ADMIRAL_PHASE);
+    console.log("Magellan Admiral2 reporter initializing" + (isSharded ? " in sharded mode " : " ")+ "with settings:");
+    console.log("              URL: " + ADMIRAL_URL);
+    console.log("          project: " + ADMIRAL_PROJECT);
+    console.log("            phase: " + ADMIRAL_PHASE);
 
-    // NOTE: Both of these conditions assume that the *project* and *phase* already exist.
+    if (isSharded) {
+      console.log("      run (shard): " + ADMIRAL_RUN);
+    }
 
-    if (ADMIRAL_RUN) {
+    // Bootstrap this project if it doesn't already exist
+    fetch(ADMIRAL_URL + "api/project/" + ADMIRAL_PROJECT, {
+        headers: { "Content-Type": "application/json" },
+        method: "POST",
+        body: JSON.stringify({})
+      })
+      .then(function(res) {
 
-      if (ADMIRAL_RUN.indexOf("\"") > -1) {
-        ADMIRAL_RUN = ADMIRAL_RUN.split("\"").join("");
-      }
-
-      // This magellan instance is contributing to a pre-existing (i.e. scaled) run
-      deferred.resolve();
-
-    } else {
-
-      // We're starting a new run
-      fetch(ADMIRAL_URL + "api/project/" + ADMIRAL_PROJECT + "/" + ADMIRAL_PHASE + "/run", {
+        // Bootstrap this phase if it doesn't already exist
+        fetch(ADMIRAL_URL + "api/project/" + ADMIRAL_PROJECT + "/" + ADMIRAL_PHASE, {
           headers: { "Content-Type": "application/json" },
           method: "POST",
-          body: JSON.stringify({ name: "run " + Math.round(Math.random() * 99999999999).toString(16) })
+          body: JSON.stringify({})
         })
         .then(function(res) {
-          return res.json();
-        })
-        .then(function(json) {
-          ADMIRAL_RUN = json._id;
-          console.log("Got admiral run id: " + ADMIRAL_RUN);
-          deferred.resolve();
-        })
-        .catch(function (e) {
-          console.log("Exception while initializing run with admiral2: ");
-          console.log(e);
-          deferred.reject();
-        })
+          
+          var runOptions = {
+            name: ADMIRAL_RUN_DISPLAY_NAME || ("run " + Math.round(Math.random() * 99999999999).toString(16))
+          };
 
-    }
+          if (isSharded) {
+            // Force the run id if we are participating in a build where multiple shards
+            // contribute to the same Admiral2 run result.
+            runOptions._id = ADMIRAL_RUN;
+          }
+
+          // Bootstrap a new run or assume an existing run
+          fetch(ADMIRAL_URL + "api/project/" + ADMIRAL_PROJECT + "/" + ADMIRAL_PHASE + "/run", {
+              headers: { "Content-Type": "application/json" },
+              method: "POST",
+              body: JSON.stringify(runOptions)
+            })
+            .then(function(res) {
+              return res.json();
+            })
+            .then(function(json) {
+              // NOTE: We no longer set ADMIRAL_RUN to json._id
+              // We ignore id that comes back since we're using our own ADMIRAL_RUN value and assuming sharding
+              if (!isSharded) {
+                ADMIRAL_RUN = json._id;
+                console.log("Got admiral run id: " + ADMIRAL_RUN);
+              } else {
+                console.log("Assumed admiral run id (in sharded mode): " + json._id);
+              }
+              deferred.resolve();
+            })
+            .catch(function (e) {
+              console.log("Exception while initializing run with Admiral2: ");
+              console.log(e);
+              deferred.reject();
+            });
+
+          return res.json();
+        });
+        
+        return res.json();
+      });
+
 
     return deferred.promise;
   },
@@ -64,9 +99,6 @@ Reporter.prototype = {
   },
 
   _handleMessage: function (test, message) {
-    // console.log("admiral reporter received message: ");
-    // console.log(message);
-
     if (message.type === "worker-status") {
       if (message.status === "started") {
         // An individual test has started running
@@ -81,13 +113,14 @@ Reporter.prototype = {
 
       } else if (message.status === "finished") {
         // An individual test has finished running
+        var resultURL = ADMIRAL_CI_BUILD_URL || "";
 
         // This is an URL for an external BaaS or DaaS system, like Saucelabs, browserstack, etc.
         // It is possible for this to be non-existent because sometimes tests fail well before
         // they've been able to establish a connection to the BaaS provider.
-        var resultURL = "";
+        var sauceURL = "";
         if (message.metadata) {
-          resultURL = message.metadata.resultURL ? message.metadata.resultURL : "";
+          sauceURL = message.metadata.resultURL ? message.metadata.resultURL : "";
         }
 
         var result = {
@@ -100,26 +133,31 @@ Reporter.prototype = {
           result.environments[test.profile.id] = {
             status: "pass",
             retries: test.attempts,
-            resultURL
+            resultURL,
+            sauceURL
           };
         } else if (test.attempts === test.maxAttempts - 1) {
           // Is this our last attempt ever? Then mark the test as finished and failed.
           result.environments[test.profile.id] = {
             status: "fail",
             retries: test.attempts,
-            resultURL
+            resultURL,
+            sauceURL
           };
         } else {
           // We've failed a test and we're going to retry it
           result.environments[test.profile.id] = {
             status: "retry",
             retries: test.attempts,
-            resultURL
+            resultURL,
+            sauceURL
           };
         }
 
-        console.log("Sending to: " + ADMIRAL_URL + "api/result/" + ADMIRAL_RUN);
-        console.log("Sending result object: ", JSON.stringify(result, null, 2));
+        if (debugMode) {
+          console.log("Sending to: " + ADMIRAL_URL + "api/result/" + ADMIRAL_RUN);
+          console.log("Sending result object: ", JSON.stringify(result, null, 2));
+        }
 
         fetch(ADMIRAL_URL + "api/result/" + ADMIRAL_RUN, {
           headers: { "Content-Type": "application/json" },
@@ -127,11 +165,15 @@ Reporter.prototype = {
           body: JSON.stringify(result)
         })
         .then(function(res) {
-          console.log("parse json from /result");
+          if (debugMode) {
+            console.log("parse json from /result");
+          }
           return res.json();
         })
         .then(function(json) {
-          console.log("got json back from /result:", json);
+          if (debugMode) {
+            console.log("got json back from /result:", json);
+          }
         })
         .catch(function (e) {
           console.log("Exception while sending data to admiral2: ");
@@ -145,7 +187,7 @@ Reporter.prototype = {
 
   flush: function () {
     // This runs only once and only at the very end when we're shutting down all the reporters
-    console.log("In flush(). Admiral2 reporter saying bye.");
+    console.log("Admiral2 reporter shutting down.");
   }
 };
 

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -7,14 +7,13 @@ function Reporter() {
 var ADMIRAL_URL = process.env.ADMIRAL_URL;
 var ADMIRAL_PROJECT = process.env.ADMIRAL_PROJECT;
 var ADMIRAL_PHASE = process.env.ADMIRAL_PHASE;
+
+// Optional
 var ADMIRAL_RUN = process.env.ADMIRAL_RUN_ID;
-
-var ADMIRAL_CI_BUILD_URL = process.env.ADMIRAL_SHARD_BUILD_URL
+var ADMIRAL_CI_BUILD_URL = process.env.ADMIRAL_CI_BUILD_URL;
 var ADMIRAL_RUN_DISPLAY_NAME = process.env.ADMIRAL_RUN_DISPLAY_NAME;
-
 var debugMode = process.env.ADMIRAL_REPORTER_DEBUG ? true : false;
-
-var isSharded = ADMIRAL_RUN ? true : false;
+var isSharded = process.env.ADMIRAL_RUN_ID ? true : false;
 
 Reporter.prototype = {
 

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -13,7 +13,6 @@ var ADMIRAL_PHASE = process.env.ADMIRAL_PHASE;
 var ADMIRAL_RUN = process.env.ADMIRAL_RUN_ID;
 var ADMIRAL_CI_BUILD_URL = process.env.ADMIRAL_CI_BUILD_URL;
 var ADMIRAL_RUN_DISPLAY_NAME = process.env.ADMIRAL_RUN_DISPLAY_NAME;
-var debugMode = process.env.ADMIRAL_REPORTER_DEBUG ? true : false;
 var isSharded = process.env.ADMIRAL_RUN_ID ? true : false;
 
 Reporter.prototype = {
@@ -104,10 +103,8 @@ Reporter.prototype = {
         // An individual test has started running
 
         if (test.attempts === 0) {
-          if (debugMode) {
-            logger.log("Test starting: " + message.name + " in environment: "
+          logger.debug("Test starting: " + message.name + " in environment: "
             + test.profile.id);
-          }
         } else {
           // Admiral1 didn't support signaling that a retry had actually *started*. It only
           // supports the notion of a retry being *queued* at time of failure. See below for more.
@@ -156,10 +153,8 @@ Reporter.prototype = {
           };
         }
 
-        if (debugMode) {
-          logger.log("Sending to: " + ADMIRAL_URL + "api/result/" + ADMIRAL_RUN);
-          logger.log("Sending result object: ", JSON.stringify(result, null, 2));
-        }
+        logger.debug("Sending to: " + ADMIRAL_URL + "api/result/" + ADMIRAL_RUN);
+        logger.debug("Sending result object: ", JSON.stringify(result, null, 2));
 
         fetch(ADMIRAL_URL + "api/result/" + ADMIRAL_RUN, {
           headers: { "Content-Type": "application/json" },
@@ -167,15 +162,11 @@ Reporter.prototype = {
           body: JSON.stringify(result)
         })
         .then(function(res) {
-          if (debugMode) {
-            logger.log("parse json from /result");
-          }
+          logger.debug("parse json from /result");
           return res.json();
         })
         .then(function(json) {
-          if (debugMode) {
-            logger.log("got json back from /result:", json);
-          }
+          logger.debug("got json back from /result:", json);
         })
         .catch(function (e) {
           logger.err("Exception while sending data to admiral2: ");


### PR DESCRIPTION
This PR updates to `4.0.0` due to breaking changes.

Summary:

#### Logging/UX
  - Added documentation for configuration to `README`
  - Adds `ADMIRAL_REPORTER_DEBUG`, which if truthy will enable more verbose logging
  - Took some of the verbose logging and hid it behind `ADMIRAL_REPORTER_DEBUG`

#### Sharding Support, Reporting
  - Adds support for multiple instances of this reporter running on different machines to contribute to the same run. If `ADMIRAL_RUN_ID` is set, it's presumed to be an unused guid shared between all shards.
  - Initialization of project / phase / run is now stacked to create the entire nested structure if it doesn't already exist.
  - Added `ADMIRAL_RUN_DISPLAY_NAME` so that runs can have a human-readable description.
  - Added `ADMIRAL_CI_BUILD_URL` so that runs can link to their CI environment's report page
  - Saucelabs URL sent to Admiral2 as `sauceURL`

/cc @jherr @archlichking 