### PR TITLE
Replaced sauceURL with sessionId

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,5 +22,8 @@
     "mocha": "^3.2.0",
     "node-fetch": "^1.5.3",
     "q": "^1.4.1"
+  },
+  "devDependencies": {
+    "nock": "^9.0.14"
   }
 }

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -184,43 +184,29 @@ Reporter.prototype = {
         // An individual test has finished running
         var resultURL = ADMIRAL_CI_BUILD_URL || "";
 
-        // This is an URL for an external BaaS or DaaS system, like Saucelabs, browserstack, etc.
-        // It is possible for this to be non-existent because sometimes tests fail well before
-        // they've been able to establish a connection to the BaaS provider.
-        var sauceURL = "";
-        if (message.metadata) {
-          sauceURL = message.metadata.resultURL ? message.metadata.resultURL : "";
-        }
+        // Get SauceLabs session id for this test session
+        var sessionId = message.metadata && message.metadata.sessionId;
 
         var result = {
           test: message.name,
-          environments: {}
+          environments: {
+            [test.profile.id]: {
+              retries: test.attempts,
+              resultURL,
+              sessionId
+            }
+          }
         };
 
         if (message.passed) {
           // We've finished a test and it passed!
-          result.environments[test.profile.id] = {
-            status: "pass",
-            retries: test.attempts,
-            resultURL,
-            sauceURL
-          };
+          result.environments[test.profile.id].status = "pass";
         } else if (test.attempts === test.maxAttempts - 1) {
           // Is this our last attempt ever? Then mark the test as finished and failed.
-          result.environments[test.profile.id] = {
-            status: "fail",
-            retries: test.attempts,
-            resultURL,
-            sauceURL
-          };
+          result.environments[test.profile.id].status = "fail";
         } else {
           // We've failed a test and we're going to retry it
-          result.environments[test.profile.id] = {
-            status: "retry",
-            retries: test.attempts,
-            resultURL,
-            sauceURL
-          };
+          result.environments[test.profile.id].status = "retry";
         }
 
         if (!self.results[message.name]) {

--- a/test/reporter.test.js
+++ b/test/reporter.test.js
@@ -1,0 +1,114 @@
+var assert = require('assert');
+var nock = require('nock');
+
+var SESSION_ID = '602f68f15d07475b9041d259a411105c';
+var ADMIRAL_URL = 'http://www.admiralNock.com/';
+var ADMIRAL_RUN_ID = '1';
+var ADMIRAL_CI_BUILD_URL = 'http://www.admiralresults.com/';
+
+describe('Reporter', function() {
+
+  var reporter;
+
+  before(function() {
+    // This probably won't work if reporter was already loaded without these env being set
+    process.env.ADMIRAL_URL = ADMIRAL_URL;
+    process.env.ADMIRAL_RUN_ID = ADMIRAL_RUN_ID;
+    process.env.ADMIRAL_CI_BUILD_URL = ADMIRAL_CI_BUILD_URL;
+    var Reporter = require('../src/reporter');
+    reporter = new Reporter();
+    reporter.results = {};
+  });
+
+  after(function() {
+    nock.cleanAll();
+  });
+
+  it('should have status=pass with sessionId', function(done) {
+
+    var admiralNock = nock(ADMIRAL_URL)
+                .filteringRequestBody(function(body) {
+                  var content = JSON.parse(body);
+                  assert.equal('pass', content.environments.master.status);
+                  assert.equal(ADMIRAL_CI_BUILD_URL, content.environments.master.resultURL);
+                  assert.equal(SESSION_ID, content.environments.master.sessionId);
+                  done();
+                  return body;
+                })
+                .post('/api/result/'+ADMIRAL_RUN_ID)
+                .reply(200, {});
+
+    reporter._handleMessage({
+      profile: {
+        id: 'master'
+      }
+    }, {
+      type: 'worker-status', 
+      status: 'finished',
+      passed: true,
+      metadata: {
+        sessionId: SESSION_ID
+      }
+    });
+    admiralNock.done();
+  });
+
+  it('should have status=retry with sessionId', function(done) {
+
+    var admiralNock = nock(ADMIRAL_URL)
+                .filteringRequestBody(function(body) {
+                  var content = JSON.parse(body);
+                  assert.equal('retry', content.environments.master.status);
+                  assert.equal(ADMIRAL_CI_BUILD_URL, content.environments.master.resultURL);
+                  assert.equal(SESSION_ID, content.environments.master.sessionId);
+                  done();
+                  return body;
+                })
+                .post('/api/result/'+ADMIRAL_RUN_ID)
+                .reply(200, {});
+
+    reporter._handleMessage({
+      profile: {
+        id: 'master'
+      }
+    }, {
+      type: 'worker-status', 
+      status: 'finished',
+      passed: false,
+      metadata: {
+        sessionId: SESSION_ID
+      }
+    });
+    admiralNock.done();
+  });
+
+  it('should have status=pass with no sessionId', function(done) {
+
+    var admiralNock = nock(ADMIRAL_URL)
+                .filteringRequestBody(function(body) {
+                  var content = JSON.parse(body);
+                  assert.equal('pass', content.environments.master.status);
+                  assert.equal(ADMIRAL_CI_BUILD_URL, content.environments.master.resultURL);
+                  assert.equal(null, content.environments.master.sessionId);
+                  done();
+                  return body;
+                })
+                .post('/api/result/'+ADMIRAL_RUN_ID)
+                .reply(200, {});
+
+    reporter._handleMessage({
+      profile: {
+        id: 'master'
+      }
+    }, {
+      type: 'worker-status', 
+      status: 'finished',
+      passed: true,
+      metadata: {
+
+      }
+    });
+    admiralNock.done();
+  });
+
+});


### PR DESCRIPTION
SauceLabs no longer seem to be returning sauceURL, but they are returning session id. We would have to use that sessionId to construct the url to the sauce results page such as https://saucelabs.com/beta/tests/1a516613340b4ef8b239d9cacecd85b2/metadata#5

Also added unit tests.