### PR TITLE
support for the split architecture of Admiral 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This is a plugin to allow `magellan` test runs to report to the Admiral2 dashboa
 |Environment Variable|Required?|Description|Example|
 |---|---|---|---|
 |ADMIRAL_URL|required|The URL of the Admiral2 server|i.e `http://host-where-admiral-lives:3000/`|
+|ADMIRAL_UI_URL|required|The URL of the Admiral2 UI|i.e. `http://host-where-admiral-UI-lives.tld`|
 |ADMIRAL_PROJECT|required|An identifier for a project|i.e. `main-app`, `blog`, `product-page`, etc|
 |ADMIRAL_PHASE|required|A lifecycle phase or build type descriptor|i.e. `pr-verify`, `master-verify`, etc|
 |ADMIRAL_CI_BUILD_URL|optional|An URL to a CI report for this run|`http://travis-ci.org/SomeOrg/someproject/builds/189605665`|

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -7,6 +7,7 @@ function Reporter() {
 }
 
 var ADMIRAL_URL = process.env.ADMIRAL_URL;
+var ADMIRAL_UI_URL = process.env.ADMIRAL_UI_URL;
 var ADMIRAL_PROJECT = process.env.ADMIRAL_PROJECT;
 var ADMIRAL_PHASE = process.env.ADMIRAL_PHASE;
 
@@ -63,6 +64,14 @@ Reporter.prototype = {
       logger.err("ADMIRAL_URL needs to be an absolute url");
       logger.warn("All following messages would be ignored");
       deferred.reject();
+
+    } else if (!ADMIRAL_UI_URL) {
+
+      this.ignoreMessages = true;
+      logger.err("ADMIRAL_UI_URL needs to be an absolute url");
+      logger.warn("All following messages would be ignored");
+      deferred.reject();
+
     } else if (!ADMIRAL_PROJECT) {
 
       this.ignoreMessages = true;
@@ -279,7 +288,7 @@ Reporter.prototype = {
           const json = res.json();
           logger.debug("Response JSON from " + ADMIRAL_URL + "api/project/" + ADMIRAL_PROJECT + "/" + ADMIRAL_PHASE + "/run/" + ADMIRAL_RUN + "/finish" + ":\n" + JSON.stringify(json, null, 2));
 
-          var reportURL = ADMIRAL_URL + "run/" + ADMIRAL_RUN;
+          var reportURL = ADMIRAL_UI_URL + "run/" + ADMIRAL_RUN;
           logger.log("Visualized test suite results available at: " + reportURL);
           return deferred.resolve();
         })


### PR DESCRIPTION
Admiral 2 is broken in to 2 components now, an API server and a UI server.

We need `ADMIRAL_URL` to reflect the API server, for reporting.

However, we need a new URL to capture where the UI lives, to display a link for the user once their run completes, to view visualized results.